### PR TITLE
CMake and Appveyor CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,56 @@
+###############################################################################
+#
+# Copyright (c) 2018, Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+image:
+  # VS 2013 doesn't support C++14, so it doesn't compile.
+  #- Visual Studio 2013
+  - Visual Studio 2015
+  - Visual Studio 2017
+
+clone_folder: c:\projects\yarpgen
+
+configuration: Release
+
+environment:
+  matrix:
+    - cmake_arch: x86
+    - cmake_arch: x64
+ 
+# skip unsupported combinations
+init:
+  - set arch=
+  - if "%cmake_arch%"=="x64" ( set arch= Win64)
+  - echo %arch%
+  - echo %APPVEYOR_BUILD_WORKER_IMAGE%
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" ( set generator="Visual Studio 15 2017%arch%" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2015" ( set generator="Visual Studio 14 2015%arch%" )
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2013" ( set generator="Visual Studio 12 2013%arch%" )
+  - echo %generator%
+
+before_build:
+- cmd: |-
+    mkdir build
+    cd build
+    cmake --version
+    cmake .. -G %generator%
+
+build:
+  project: c:\projects\yarpgen\build\YARPGen.sln
+  verbosity: minimal
+  parallel: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,21 @@
+###############################################################################
+#
+# Copyright (c) 2018, Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
 language: cpp
 matrix:
   include:
@@ -30,6 +48,9 @@ matrix:
         - MATRIX_EVAL="CC=clang && CXX=clang++"
 
 before_install:
-      - eval "${MATRIX_EVAL}"
-script: make
+  - eval "${MATRIX_EVAL}"
 
+script:
+  - mkdir build; cd build
+  - cmake -DCMAKE_BUILD_TYPE=Release ..
+  - make -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+###############################################################################
+#
+# Copyright (c) 2018, Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+cmake_minimum_required (VERSION 3.6)
+project (YARPGen)
+
+if(NOT DEFINED YARPGEN_VERSION_MAJOR)
+  set(YARPGEN_VERSION_MAJOR 1)
+endif()
+if(NOT DEFINED YARPGEN_VERSION_MINOR)
+  set(YARPGEN_VERSION_MINOR 2)
+endif()
+
+STRING(TIMESTAMP BUILD_DATE "%Y:%m:%d")
+
+find_package(Git)
+set(GIT_HASH "no_version_info")
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} log -1 --format=%h HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif()
+
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/intel/yarpgen.svg?branch=master)](https://travis-ci.org/intel/yarpgen)
+[![Linux Build Status](https://travis-ci.org/intel/yarpgen.svg?branch=master)](https://travis-ci.org/intel/yarpgen)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/intel/yarpgen?branch=master&svg=true)(https://ci.appveyor.com/project/intel/yarpgen)]
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/intel/yarpgen/blob/master/LICENSE.txt)
 
 Yet Another Random Program Generator

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,29 @@
+###############################################################################
+#
+# Copyright (c) 2018, Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###############################################################################
+
+set(LIB_SRCS type.cpp variable.cpp expr.cpp stmt.cpp gen_policy.cpp sym_table.cpp program.cpp options.cpp)
+
+set(SRCS ${LIB_SRCS} main.cpp self-test.cpp)
+
+add_executable(yarpgen ${SRCS})
+
+target_compile_features(yarpgen PRIVATE cxx_std_14)
+target_compile_definitions(yarpgen PRIVATE BUILD_VERSION="${GIT_HASH}" BUILD_DATE="${BUILD_DATE}")
+target_compile_options(yarpgen PRIVATE
+  #  $<$<CXX_COMPILER_ID:MSVC>:/WX>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:-Wall -Wpedantic -Werror>)

--- a/src/expr.cpp
+++ b/src/expr.cpp
@@ -188,7 +188,7 @@ std::shared_ptr<TypeCastExpr> TypeCastExpr::generate (std::shared_ptr<Context> c
 void TypeCastExpr::emit (std::ostream& stream, std::string offset) {
     std::string ret = offset;
     //TODO: add parameter to gen_policy
-    if (!is_implicit or is_implicit)
+    if (!is_implicit || is_implicit)
         stream << "(" << value->get_type()->get_simple_name() << ") ";
     stream << "(";
     expr->emit(stream);

--- a/src/gen_policy.h
+++ b/src/gen_policy.h
@@ -60,7 +60,13 @@ class RandValGen {
 
         template<typename T>
         T get_rand_value (T from, T to) {
-            std::uniform_int_distribution<T> dis(from, to);
+            // Using long long instead of T is a hack.
+            // get_rand_value is used with all kind of integer types, including chars.
+            // While standard is not allowing it to be used with uniform_int_distribution<>
+            // algorithm. Though, clang and gcc ok with it, but VS doesn't compile such code.
+            // For details see C++17, $26.5.1.1e [rand.req.genl]. This issue is also discussed
+            // in issue 2326 (closed as not a defect and reopened as feature request N4296).
+            std::uniform_int_distribution<long long> dis(from, to);
             return dis(rand_gen);
         }
 
@@ -77,7 +83,7 @@ class RandValGen {
         // Randomly chooses one of vec elements
         template<typename T>
         T& get_rand_elem (std::vector<T>& vec) {
-            uint64_t idx = get_rand_value(0UL, vec.size() - 1);
+            uint64_t idx = get_rand_value<uint64_t>(0, vec.size() - 1);
             return vec.at(idx);
         }
 

--- a/src/stmt.cpp
+++ b/src/stmt.cpp
@@ -308,8 +308,8 @@ std::shared_ptr<ScopeStmt> ScopeStmt::generate (std::shared_ptr<Context> ctx) {
 
                 // This function randomly picks element from vector.
                 // Also it optionally returns picked element's id in ret_rand_num
-                auto pick_elem = [&assign_lhs](auto vector_of_exprs, uint32_t *ret_rand_num = nullptr) {
-                    uint64_t rand_num = rand_val_gen->get_rand_value(0UL, vector_of_exprs.size() - 1);
+                auto pick_elem = [&assign_lhs](auto vector_of_exprs, size_t *ret_rand_num = nullptr) {
+                    size_t rand_num = rand_val_gen->get_rand_value<size_t>(0, vector_of_exprs.size() - 1);
                     assign_lhs = vector_of_exprs.at(rand_num);
                     if (ret_rand_num != nullptr)
                         *ret_rand_num = rand_num;
@@ -330,13 +330,13 @@ std::shared_ptr<ScopeStmt> ScopeStmt::generate (std::shared_ptr<Context> ctx) {
                         pick_elem(ctx->get_extern_out_sym_table()->get_var_use_exprs_in_arrays());
                         // Use member of output struct
                     else if (out_data_type == GenPolicy::OutDataTypeID::MEMBER) {
-                        uint32_t elem_num;
+                        size_t elem_num;
                         pick_elem(ctx->get_extern_out_sym_table()->get_members_in_structs(), &elem_num);
                         ctx->get_extern_out_sym_table()->del_member_in_structs(elem_num);
                     }
                         // Use member of struct in output array
                     else if (out_data_type == GenPolicy::OutDataTypeID::MEMBER_IN_ARRAY) {
-                        uint32_t elem_num;
+                        size_t elem_num;
                         pick_elem(ctx->get_extern_out_sym_table()->get_members_in_arrays(), &elem_num);
                         ctx->get_extern_out_sym_table()->del_member_in_arrays(elem_num);
                     }

--- a/src/sym_table.cpp
+++ b/src/sym_table.cpp
@@ -135,12 +135,12 @@ void SymbolTable::add_pointer(std::shared_ptr<Pointer> ptr, std::shared_ptr<Expr
     pointers.deref_expr.push_back(deep_deref_expr_from_nest_ptr(deref_expr));
 }
 
-void SymbolTable::del_member_in_structs(int idx) {
+void SymbolTable::del_member_in_structs(size_t idx) {
     auto& member_exprs = std::get<ALL>(members_in_structs);
     member_exprs.erase(member_exprs.begin() + idx);
 }
 
-void SymbolTable::del_member_in_arrays(int idx) {
+void SymbolTable::del_member_in_arrays(size_t idx) {
     auto& member_exprs = std::get<ALL>(members_in_arrays);
     member_exprs.erase(member_exprs.begin() + idx);
 }

--- a/src/sym_table.h
+++ b/src/sym_table.h
@@ -67,11 +67,11 @@ class SymbolTable {
 
         auto& get_members_in_structs() { return std::get<ALL>(members_in_structs); }
         auto& get_const_members_in_structs() { return std::get<CONST>(members_in_structs); }
-        void del_member_in_structs(int idx);
+        void del_member_in_structs(size_t idx);
 
         auto& get_members_in_arrays() { return std::get<ALL>(members_in_arrays); }
         auto& get_const_members_in_arrays() { return std::get<CONST>(members_in_arrays); }
-        void del_member_in_arrays(int idx);
+        void del_member_in_arrays(size_t idx);
 
         std::vector<std::string> get_lval_ptr_map_keys() { return lval_ptr_map_keys; }
         std::map<std::string, ExprVector>& get_lval_expr_with_ptr_type() { return lval_expr_with_ptr_type; }

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -2154,8 +2154,8 @@ std::shared_ptr<ArrayType> ArrayType::generate(std::shared_ptr<Context> ctx) {
         base_type = IntegerType::generate(ctx);
     }
     else if (base_type_id == TypeID::STRUCT_TYPE) {
-        uint32_t struct_type_idx = rand_val_gen->get_rand_value(
-                                   0UL, ctx->get_extern_inp_sym_table()->get_struct_types().size() - 1);
+        size_t struct_type_idx = rand_val_gen->get_rand_value<size_t>(
+                                   0, ctx->get_extern_inp_sym_table()->get_struct_types().size() - 1);
         base_type = ctx->get_extern_inp_sym_table()->get_struct_types().at(struct_type_idx);
     }
     else


### PR DESCRIPTION
Moving build system to CMake to be able to easily compile for both Linux and Windows.
Also adding Appveyor CI - builds on Windows.
Still some clean up is required to build on Windows without warnings.