### PR TITLE
Fix the broken data test

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -44,6 +44,8 @@ std::shared_ptr<ScalarVar> ScalarVar::create(std::shared_ptr<PopulateCtx> ctx) {
 }
 
 std::string ScalarVar::getName(std::shared_ptr<EmitCtx> ctx) {
+    if (!ctx)
+        return name;
     std::string ret;
     if (!ctx->getSYCLPrefix().empty())
         ret = ctx->getSYCLPrefix();


### PR DESCRIPTION
I found that running `data_test` results in Segmentation fault:

```
$ ./data_test
Test seed: 447612407
Segmentation fault: 11
```

It's because `std::shared_ptr<EmitCtx>()` is a null pointer, and `ScalarVar::getName` is still trying to access its data/members.

Therefore, the fix is if the pointer is null, simply `return name`, which is the default behavior from the parent object.