### PR TITLE
Unsigned long long generator fix

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -37,10 +37,10 @@ RandValGen::RandValGen(uint64_t _seed) {
     rand_gen = std::mt19937_64(seed);
 }
 
-#define RandValueCase(__type_id__, type_name)                                  \
+#define RandValueCase(__type_id__, gen_name, type_name)                        \
     case __type_id__:                                                          \
         do {                                                                   \
-            ret.getValueRef<type_name>() = getRandValue<type_name>();          \
+            ret.getValueRef<type_name>() = gen_name<type_name>();              \
             ret.setUBCode(UBKind::NoUB);                                       \
             return ret;                                                        \
         } while (false)
@@ -52,15 +52,19 @@ IRValue RandValGen::getRandValue(IntTypeID type_id) {
     IRValue ret(type_id);
     switch (type_id) {
         // TODO: if we use chains of if we can make it simpler
-        RandValueCase(IntTypeID::BOOL, TypeBool::value_type);
-        RandValueCase(IntTypeID::SCHAR, TypeSChar::value_type);
-        RandValueCase(IntTypeID::UCHAR, TypeUChar::value_type);
-        RandValueCase(IntTypeID::SHORT, TypeSShort::value_type);
-        RandValueCase(IntTypeID::USHORT, TypeUShort::value_type);
-        RandValueCase(IntTypeID::INT, TypeSInt::value_type);
-        RandValueCase(IntTypeID::UINT, TypeUInt::value_type);
-        RandValueCase(IntTypeID::LLONG, TypeSLLong::value_type);
-        RandValueCase(IntTypeID::ULLONG, TypeULLong::value_type);
+        RandValueCase(IntTypeID::BOOL, getRandValue, TypeBool::value_type);
+        RandValueCase(IntTypeID::SCHAR, getRandValue, TypeSChar::value_type);
+        RandValueCase(IntTypeID::UCHAR, getRandUnsignedValue,
+                      TypeUChar::value_type);
+        RandValueCase(IntTypeID::SHORT, getRandValue, TypeSShort::value_type);
+        RandValueCase(IntTypeID::USHORT, getRandUnsignedValue,
+                      TypeUShort::value_type);
+        RandValueCase(IntTypeID::INT, getRandValue, TypeSInt::value_type);
+        RandValueCase(IntTypeID::UINT, getRandUnsignedValue,
+                      TypeUInt::value_type);
+        RandValueCase(IntTypeID::LLONG, getRandValue, TypeSLLong::value_type);
+        RandValueCase(IntTypeID::ULLONG, getRandUnsignedValue,
+                      TypeULLong::value_type);
         case IntTypeID::MAX_INT_TYPE_ID:
             ERROR("Bad IntTypeID");
             break;

--- a/src/utils.h
+++ b/src/utils.h
@@ -95,6 +95,14 @@ class RandValGen {
         return dis(rand_gen);
     }
 
+    template <typename T> T getRandUnsignedValue() {
+        // See note above about long long hack
+        std::uniform_int_distribution<unsigned long long> dis(
+            0,
+            static_cast<unsigned long long>(std::numeric_limits<T>::max()));
+        return dis(rand_gen);
+    }
+
     IRValue getRandValue(IntTypeID type_id);
 
     // Randomly chooses one of IDs, basing on std::vector<Probability<id>>.


### PR DESCRIPTION
Currently, the random value generator is using a `long long` uniform distribution. Unfortunately, this is not correct for some types, like `unsigned long long`. The problem is, the `numeric_limits<unsigned long long>::max()` value cannot be represented as `long long`, and the following assertion will fire in STL: https://github.com/microsoft/STL/blob/68b344c9dcda6ddf1a8fca112cb9033f9e50e787/stl/inc/random#L1758

I added a `getRandUnsignedValue` function with `unsigned long long` uniform distribution to remedy the problem. Let me know if you had something else in mind.