### PR TITLE
Change arrays and iterators generation

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -34,6 +34,7 @@ PopulateCtx::PopulateCtx(std::shared_ptr<PopulateCtx> _par_ctx)
         arith_depth = par_ctx->getArithDepth();
         taken = par_ctx->isTaken();
         inside_omp_simd = par_ctx->inside_omp_simd;
+        dims = par_ctx->dims;
     }
 }
 
@@ -45,4 +46,20 @@ PopulateCtx::PopulateCtx() {
     arith_depth = 0;
     taken = true;
     inside_omp_simd = false;
+}
+
+void SymbolTable::addArray(std::shared_ptr<Array> array) {
+    arrays.push_back(array);
+    assert(array->getType()->isArrayType() &&
+           "Array should have an array type");
+    auto array_type = std::static_pointer_cast<ArrayType>(array->getType());
+    array_dim_map[array_type->getDimensions().size()].push_back(array);
+}
+
+std::vector<std::shared_ptr<Array>>
+SymbolTable::getArraysWithDimNum(size_t dim) {
+    auto find_res = array_dim_map.find(dim);
+    if (find_res != array_dim_map.end())
+        return find_res->second;
+    return {};
 }

--- a/src/context.h
+++ b/src/context.h
@@ -73,7 +73,7 @@ class GenCtx {
 class SymbolTable {
   public:
     void addVar(std::shared_ptr<ScalarVar> var) { vars.push_back(var); }
-    void addArray(std::shared_ptr<Array> array) { arrays.push_back(array); }
+    void addArray(std::shared_ptr<Array> array);
     void addIters(std::vector<std::shared_ptr<Iterator>> iter) {
         iters.push_back(iter);
     }
@@ -81,15 +81,9 @@ class SymbolTable {
 
     std::vector<std::shared_ptr<ScalarVar>> getVars() { return vars; }
     std::vector<std::shared_ptr<Array>> getArrays() { return arrays; }
+    std::vector<std::shared_ptr<Array>> getArraysWithDimNum(size_t dim);
     std::vector<std::vector<std::shared_ptr<Iterator>>> getIters() {
         return iters;
-    }
-
-    void addSubsExpr(std::shared_ptr<SubscriptExpr> expr) {
-        avail_subs.push_back(expr);
-    }
-    std::vector<std::shared_ptr<SubscriptExpr>> getAvailSubs() {
-        return avail_subs;
     }
 
     void addVarExpr(std::shared_ptr<ScalarVarUseExpr> var) {
@@ -103,8 +97,8 @@ class SymbolTable {
   private:
     std::vector<std::shared_ptr<ScalarVar>> vars;
     std::vector<std::shared_ptr<Array>> arrays;
+    std::map<size_t, std::vector<std::shared_ptr<Array>>> array_dim_map;
     std::vector<std::vector<std::shared_ptr<Iterator>>> iters;
-    std::vector<std::shared_ptr<SubscriptExpr>> avail_subs;
     std::vector<std::shared_ptr<ScalarVarUseExpr>> avail_vars;
 };
 
@@ -135,6 +129,10 @@ class PopulateCtx : public GenCtx {
     void setInsideOMPSimd(bool val) { inside_omp_simd = val; }
     bool isInsideOMPSimd() { return inside_omp_simd; }
 
+    void addDimension(size_t dim) { dims.push_back(dim); }
+    std::vector<size_t> getDimensions() { return dims; }
+    void deleteLastDim() { dims.pop_back(); }
+
   private:
     std::shared_ptr<PopulateCtx> par_ctx;
     std::shared_ptr<SymbolTable> ext_inp_sym_tbl;
@@ -147,6 +145,9 @@ class PopulateCtx : public GenCtx {
     // As of now, the pragma omp simd is attached to a loop and can't be nested.
     // TODO: we need to think about pragma omp ordered simd
     bool inside_omp_simd;
+
+    // Each loop header has a limit that any iterator should respect
+    std::vector<size_t> dims;
 };
 
 // TODO: maybe we need to inherit from some class

--- a/src/data.h
+++ b/src/data.h
@@ -178,7 +178,7 @@ class Iterator : public Data {
 
     void dbgDump() final;
 
-    static std::shared_ptr<Iterator> create(std::shared_ptr<GenCtx> ctx,
+    static std::shared_ptr<Iterator> create(std::shared_ptr<PopulateCtx> ctx,
                                             bool is_uniform = true);
     void populate(std::shared_ptr<PopulateCtx> ctx);
 

--- a/src/expr.h
+++ b/src/expr.h
@@ -290,6 +290,8 @@ class SubscriptExpr : public Expr {
     void emit(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
               std::string offset = "") final;
     static std::shared_ptr<SubscriptExpr>
+    init(std::shared_ptr<Array> arr, std::shared_ptr<PopulateCtx> ctx);
+    static std::shared_ptr<SubscriptExpr>
     create(std::shared_ptr<PopulateCtx> ctx);
     void setValue(std::shared_ptr<Expr> _expr);
 

--- a/src/stmt.h
+++ b/src/stmt.h
@@ -140,6 +140,9 @@ class LoopHead {
     void createPragmas(std::shared_ptr<PopulateCtx> ctx);
     bool hasSIMDPragma();
 
+    static void populateArrays(std::shared_ptr<PopulateCtx> ctx);
+    void populateIters(std::shared_ptr<PopulateCtx> ctx);
+
   private:
     std::shared_ptr<StmtBlock> prefix;
     // Loop iterations space is defined by the iterators that we can use

--- a/src/type.cpp
+++ b/src/type.cpp
@@ -249,35 +249,11 @@ std::string ArrayType::getName(std::shared_ptr<EmitCtx> ctx) {
     return base_type->getName(ctx) + " *";
 }
 
-std::shared_ptr<ArrayType>
-ArrayType::create(std::shared_ptr<PopulateCtx> ctx,
-                  std::vector<std::shared_ptr<Iterator>> &used_iters) {
+std::shared_ptr<ArrayType> ArrayType::create(std::shared_ptr<PopulateCtx> ctx) {
     auto gen_pol = ctx->getGenPolicy();
     IntTypeID base_type_id = rand_val_gen->getRandId(gen_pol->int_type_distr);
     auto base_type = IntegralType::init(base_type_id);
-    std::vector<size_t> dims;
-    dims.reserve(ctx->getLoopDepth());
-    assert(ctx->getLocalSymTable()->getIters().size() == ctx->getLoopDepth() &&
-           "Each loop should have an iterator");
-    auto avail_iters = ctx->getLocalSymTable()->getIters();
-    EvalCtx eval_ctx;
-    used_iters.reserve(ctx->getLoopDepth());
-    for (size_t i = 0; i < ctx->getLoopDepth(); ++i) {
-        size_t new_dim_idx = rand_val_gen->getRandValue(
-            static_cast<size_t>(0), avail_iters.at(i).size() - 1);
-        std::shared_ptr<Iterator> iter = avail_iters.at(i).at(new_dim_idx);
-        used_iters.push_back(iter);
-        Expr::EvalResType end_var = iter->getEnd()->evaluate(eval_ctx);
-        assert(end_var->getKind() == DataKind::VAR &&
-               "We can deal only with simple iterators for now.");
-        IRValue end_val =
-            std::static_pointer_cast<ScalarVar>(end_var)->getCurrentValue();
-        IRValue::AbsValue end_abs_val = end_val.getAbsValue();
-        if (end_abs_val.isNegative)
-            ERROR("End value can't be negative for now.");
-        dims.push_back(end_abs_val.value + 1);
-    }
-    return init(base_type, dims);
+    return init(base_type, ctx->getDimensions());
 }
 
 std::shared_ptr<Type> ArrayType::makeVarying() {

--- a/src/type.h
+++ b/src/type.h
@@ -320,9 +320,7 @@ class ArrayType : public Type {
          bool _is_static, CVQualifier _cv_qual, bool _is_uniform = true);
     static std::shared_ptr<ArrayType> init(std::shared_ptr<Type> _base_type,
                                            std::vector<size_t> _dims);
-    static std::shared_ptr<ArrayType>
-    create(std::shared_ptr<PopulateCtx> ctx,
-           std::vector<std::shared_ptr<Iterator>> &used_iters);
+    static std::shared_ptr<ArrayType> create(std::shared_ptr<PopulateCtx> ctx);
 
     std::shared_ptr<Type> makeVarying() override;
 


### PR DESCRIPTION
The main idea of this commit is to separate loop bounds from arrays and iterators. From now on the loop itself determines valid range, and iterators and arrays are created with respect to this range. It allows us to simplify dependecies between different parts of the generator and builds foundation for pattern generation.