### PR TITLE
Fix and improve mutation strategy

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -25,7 +25,7 @@ using namespace yarpgen;
 PopulateCtx::PopulateCtx(std::shared_ptr<PopulateCtx> _par_ctx)
     : par_ctx(std::move(_par_ctx)), ext_inp_sym_tbl(par_ctx->ext_inp_sym_tbl),
       ext_out_sym_tbl(par_ctx->ext_out_sym_tbl), arith_depth(0), taken(true),
-      inside_omp_simd(false) {
+      inside_mutation(false), inside_omp_simd(false) {
     local_sym_tbl = std::make_shared<SymbolTable>();
     if (par_ctx.use_count() != 0) {
         local_sym_tbl =
@@ -33,6 +33,7 @@ PopulateCtx::PopulateCtx(std::shared_ptr<PopulateCtx> _par_ctx)
         loop_depth = par_ctx->getLoopDepth();
         arith_depth = par_ctx->getArithDepth();
         taken = par_ctx->isTaken();
+        inside_mutation = par_ctx->isInsideMutation();
         inside_omp_simd = par_ctx->inside_omp_simd;
         dims = par_ctx->dims;
     }
@@ -45,6 +46,7 @@ PopulateCtx::PopulateCtx() {
     ext_out_sym_tbl = std::make_shared<SymbolTable>();
     arith_depth = 0;
     taken = true;
+    inside_mutation = false;
     inside_omp_simd = false;
 }
 

--- a/src/context.h
+++ b/src/context.h
@@ -126,6 +126,9 @@ class PopulateCtx : public GenCtx {
     bool isTaken() { return taken; }
     void setTaken(bool _taken) { taken = _taken; }
 
+    bool isInsideMutation() { return inside_mutation; }
+    void setIsInsideMutation(bool _val) { inside_mutation = _val; }
+
     void setInsideOMPSimd(bool val) { inside_omp_simd = val; }
     bool isInsideOMPSimd() { return inside_omp_simd; }
 
@@ -141,6 +144,9 @@ class PopulateCtx : public GenCtx {
     size_t arith_depth;
     // If the test will actually execute the code
     bool taken;
+
+    // This flag indicates if we are inside a region that we try to mutate
+    bool inside_mutation;
 
     // As of now, the pragma omp simd is attached to a loop and can't be nested.
     // TODO: we need to think about pragma omp ordered simd

--- a/src/enums.h
+++ b/src/enums.h
@@ -209,4 +209,7 @@ enum class SpecialConst {
 };
 
 enum class CheckAlgo { HASH, ASSERTS, PRECOMPUTE, MAX_CHECK_ALGO };
+
+enum class MutationKind { NONE, EXPRS, ALL, MAX_MUTATION_FIND };
+
 } // namespace yarpgen

--- a/src/gen_policy.h
+++ b/src/gen_policy.h
@@ -140,19 +140,6 @@ class GenPolicy {
     std::vector<Probability<bool>> use_const_transform_distr;
     std::vector<Probability<UnaryOp>> const_transform_distr;
 
-    template <typename F> auto makeMutatableDecision(F function_call) {
-        auto res = function_call();
-        Options &options = Options::getInstance();
-        if (options.getMutate()) {
-            rand_val_gen->switchMutationStates();
-            bool mutate = rand_val_gen->getRandId(mutation_probability);
-            if (mutate)
-                res = function_call();
-            rand_val_gen->switchMutationStates();
-        }
-        return res;
-    }
-
   private:
     template <typename T>
     void uniformProbFromMax(std::vector<Probability<T>> &distr, size_t max_num,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,17 +34,9 @@ int main(int argc, char *argv[]) {
     rand_val_gen = std::make_shared<RandValGen>(options.getSeed());
     options.setSeed(rand_val_gen->getSeed());
 
-    if (options.getMutate()) {
-        if (options.getMutationSeed() == 0)
-            options.setMutationSeed(
-                rand_val_gen->getRandValue(std::numeric_limits<size_t>::min(),
-                                           std::numeric_limits<size_t>::max()));
-        rand_val_gen->switchMutationStates();
-        rand_val_gen->setSeed(options.getMutationSeed());
-        rand_val_gen->switchMutationStates();
-
-        std::cout << "/*MUTATION_SEED " << options.getMutationSeed() << "*/"
-                  << std::endl;
+    if (options.getMutationKind() == MutationKind::EXPRS ||
+        options.getMutationKind() == MutationKind::ALL) {
+        rand_val_gen->setMutationSeed(options.getMutationSeed());
     }
 
     ProgramGenerator new_program;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -180,11 +180,12 @@ std::vector<OptionDescr> yarpgen::OptionParser::options_set{
      "",
      "--mutate",
      true,
-     "Mutate the test",
+     "Test mutation type. Can be disabled, set to mutate expressions "
+     "only or mutate mote parameters",
      "Can't parse mutate parameter",
-     OptionParser::parseMutate,
-     "false",
-     {"true", "false"}},
+     OptionParser::parseMutationKind,
+     "none",
+     {"none", "exprs", "all"}},
     {OptionKind::MUTATION_SEED,
      "",
      "--mutation-seed",
@@ -480,12 +481,14 @@ void OptionParser::parseMutationSeed(std::string mutation_seed_str) {
     options.setMutationSeed(seed);
 }
 
-void OptionParser::parseMutate(std::string mutate_str) {
+void OptionParser::parseMutationKind(std::string mutate_str) {
     Options &options = Options::getInstance();
-    if (mutate_str == "true")
-        options.setMutate(true);
-    else if (mutate_str == "false")
-        options.setMutate(false);
+    if (mutate_str == "none")
+        options.setMutationKind(MutationKind::NONE);
+    else if (mutate_str == "exprs")
+        options.setMutationKind(MutationKind::EXPRS);
+    else if (mutate_str == "all")
+        options.setMutationKind(MutationKind::ALL);
     else
         printHelpAndExit("Can't recognize mutation parameters");
 }

--- a/src/options.h
+++ b/src/options.h
@@ -95,7 +95,7 @@ class OptionParser {
     static void parseOutDir(std::string val);
     static void parseUseParamShuffle(std::string val);
     static void parseExplLoopParams(std::string val);
-    static void parseMutate(std::string mutate_str);
+    static void parseMutationKind(std::string mutate_str);
     static void parseMutationSeed(std::string mutation_seed_str);
 };
 
@@ -150,8 +150,8 @@ class Options {
     void setExplLoopParams(bool val) { expl_loop_params = val; }
     bool getExplLoopParams() { return expl_loop_params; }
 
-    void setMutate(bool val) { mutate = val; }
-    bool getMutate() { return mutate; }
+    void setMutationKind(MutationKind val) { mutation_kind = val; }
+    MutationKind getMutationKind() { return mutation_kind; }
 
     void setMutationSeed(size_t val) { mutation_seed = val; }
     size_t getMutationSeed() { return mutation_seed; }
@@ -191,7 +191,7 @@ class Options {
     // Explicit loop parameters. Some applications need that option available
     bool expl_loop_params;
 
-    bool mutate;
+    MutationKind mutation_kind;
     size_t mutation_seed;
 };
 } // namespace yarpgen

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -72,12 +72,21 @@ IRValue RandValGen::getRandValue(IntTypeID type_id) {
     return ret;
 }
 
-void RandValGen::switchMutationStates() {
-    std::stringstream tmp_state;
-    std::swap(prev_gen, rand_gen);
-}
+// Swap random generators that we use to make random decisions
+void RandValGen::switchMutationStates() { std::swap(prev_gen, rand_gen); }
 
 void RandValGen::setSeed(uint64_t new_seed) {
     seed = new_seed;
     rand_gen = std::mt19937_64(seed);
+}
+
+// Mutations are driven by auxiliary random generator.
+// We use a separate mutation seed to set its initial state
+void RandValGen::setMutationSeed(uint64_t mutation_seed) {
+    if (mutation_seed == 0) {
+        std::random_device rd;
+        mutation_seed = rd();
+    }
+    std::cout << "/*MUTATION_SEED " << mutation_seed << "*/" << std::endl;
+    prev_gen = std::mt19937_64(mutation_seed);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -56,16 +56,29 @@ template <typename T> class Probability {
     void increaseProb(uint64_t add_prob) { prob += add_prob; }
     void zeroProb() { prob = 0; }
     void setProb(uint64_t _prob) { prob = _prob; }
+
+    template <class U>
     friend std::ostream &operator<<(std::ostream &os,
-                                    const Probability<T> &_prob) {
-        os << _prob.id << " : " << _prob.prob;
-        return os;
-    }
+                                    const Probability<U> &_prob);
 
   private:
     T id;
     uint64_t prob;
 };
+
+template <class T>
+typename std::enable_if<!std::is_enum<T>::value, std::ostream &>::type
+operator<<(std::ostream &os, const Probability<T> &_prob) {
+    os << _prob.id << " : " << _prob.prob;
+    return os;
+}
+
+template <class T>
+typename std::enable_if<std::is_enum<T>::value, std::ostream &>::type
+operator<<(std::ostream &os, const Probability<T> &_prob) {
+    os << static_cast<long long int>(_prob.id) << " : " << _prob.prob;
+    return os;
+}
 
 // According to the agreement, Random Value Generator is the only way to get any
 // random value in YARPGen. It is used for different random decisions all over
@@ -152,12 +165,13 @@ class RandValGen {
 
     uint64_t getSeed() { return seed; }
     void setSeed(uint64_t new_seed);
-
     void switchMutationStates();
+    void setMutationSeed(uint64_t mutation_seed);
 
   private:
     uint64_t seed;
     std::mt19937_64 rand_gen;
+    // Auxiliary random generator, used for mutation
     std::mt19937_64 prev_gen;
 };
 


### PR DESCRIPTION
The goal of this commit is to fix and improve experimental mutation mechanism that already exists in YARPGen.

Mutation mechanism is designed to produce tests that are almost the same, but differ in subtle details (e.g, they use different arithmetic expressions in some places). This feature is necessary for alive2 testing and allows us to expand YARPGen to new domains.

I've added various levels of mutation (scope, expressions) and isolated mutation decisions from the main logic.