### PR TITLE
Fix Appveyor Ubuntu x86

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -73,7 +73,7 @@ for:
       then
         export extra_cmake_flags=-DCMAKE_CXX_FLAGS=-m32;
         sudo apt-get update;
-        sudo apt-get install -y g++-multilib;
+        sudo apt-get install -y g++-9-multilib;
       fi;
       cmake --version
 


### PR DESCRIPTION
Update Appveyor to install multilib corresponding to the latest compiler: `g++-9-multilib`.
This fixes Appveyor build on Ubuntu x86 (32 bit).