### PR TITLE
Roll back SDE version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,8 @@ ENV LLVM_HOME=$TESTING_HOME/llvm
 ARG LLVM_REPO=https://github.com/llvm/llvm-project.git
 ARG LLVM_VERSION=main
 
-ARG SDE_REPO=https://downloadmirror.intel.com/732268
-ARG SDE_VERSION=sde-external-9.7.0-2022-05-09-lin
+ARG SDE_REPO=https://downloadmirror.intel.com/684899
+ARG SDE_VERSION=sde-external-9.0.0-2021-11-07-lin
 
 ENV YARPGEN_HOME=$TESTING_HOME/yarpgen
 ARG YARPGEN_REPO=https://github.com/intel/yarpgen


### PR DESCRIPTION
The current SDE version (sde-external-9.7.0-2022-05-09) does not work properly on some of the AMD chips to emulate sapphire rapids. The solution is to roll back to the previous version.