### PR TITLE
Adjust default options for C++ and change test results folder name

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,8 +8,9 @@ then
     cd $YARPGEN_HOME/scripts
 else
     # Create output dir
-    DATE=$(date '+%m-%d-%y')
-    OUT_DIR=$RESULT_DIR/$DATE-$HOST_HOSTNAME
+    # date-time format is the following: 20230123_1622 for 2023 Jan 23, 16:22.
+    DATETIME=$(date '+%Y%m%d_%k%M')
+    OUT_DIR=$RESULT_DIR/$DATETIME-$HOST_HOSTNAME
     mkdir $OUT_DIR
 
     # Save revisions

--- a/scripts/test_sets.txt
+++ b/scripts/test_sets.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright (c) 2016-2020, Intel Corporation
+# Copyright (c) 2016-2023, Intel Corporation
 # Copyright (c) 2019-2020, University of Utah
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,19 +30,19 @@ Compiler specs:
 # Arch prefix - prefix for specifying different architectures (it will be concatenated with Compiler arch value)
 
 # Spec name | C++ executable name | C executable name | Common arguments                                            | Arch prefix
-gcc         | g++                 | gcc               | -w -fpermissive                                             | -march=
-clang       | clang++             | clang             | -w -fopenmp-simd                                            | -march=
-polly       | clang++             | clang             | -w -fopenmp-simd -mllvm -polly -mllvm -polly-vectorizer=stripmine | -march=
+gcc         | g++                 | gcc               | -fPIC -mcmodel=large -w -fpermissive                                             | -march=
+clang       | clang++             | clang             | -fPIC -mcmodel=large -w -fopenmp-simd                                            | -march=
+polly       | clang++             | clang             | -fPIC -mcmodel=large -w -fopenmp-simd -mllvm -polly -mllvm -polly-vectorizer=stripmine | -march=
 # Ubsan is clang or gcc with sanitizer options. It is used for generator check.
 # If you want to use sanitizer with -m32, please make sure that you pass "-rtlib=compiler-rt -lgcc_s" options if you are using clang.
 # Otherwise it may fail with "undefined reference to `__mulodi4'" error message.
 # See https://bugs.llvm.org//show_bug.cgi?id=16404 for more information
 # Note that -fpermissive option for gcc is required to allow reduction of ubsan_gcc fails.
 # Otherwise result of reducion is empty program.
-ubsan_clang | clang++             | clang             | -fsanitize=undefined -fno-sanitize-recover=undefined -Werror=uninitialized -Werror=implicitly-unsigned-literal | -march=
-ubsan_gcc   | g++                 | gcc               | -fsanitize=undefined -fno-sanitize-recover=undefined -Werror=uninitialized -fpermissive | -march=
-icc         | icpc                | icc               | -w                                                          | -x
-icx         | icpx                | icx               | -w -fopenmp-simd -mllvm -vec-threshold=0                    | -march=
+ubsan_clang | clang++             | clang             | -fPIC -mcmodel=large -fsanitize=undefined -fno-sanitize-recover=undefined -Werror=uninitialized -Werror=implicitly-unsigned-literal | -march=
+ubsan_gcc   | g++                 | gcc               | -fPIC -mcmodel=large -fsanitize=undefined -fno-sanitize-recover=undefined -Werror=uninitialized -fpermissive | -march=
+icc         | icpc                | icc               | -fPIC -mcmodel=large -w                                                          | -x
+icx         | icpx                | icx               | -fPIC -mcmodel=large -w -fopenmp-simd -mllvm -vec-threshold=0                    | -march=
 dpcpp       | clang++             | clang             | -fsycl -w                                                   | -march=
 ispc        | ispc-proxy          | ispc-proxy        | -woff                                                       | --target=
 


### PR DESCRIPTION
- `-fPIC -mcmodel=large` is needed to avoid crashes due to too large binary size. The downside is that previously these testes were crashing with clear compile time message, but now may consume too much resources in runtime.
- Change format of result folder name in docker. Now it's sortable and has time (allow disambiguation for multiple runs a day).