### PR TITLE
Add missing header.

### DIFF
--- a/src/options.h
+++ b/src/options.h
@@ -19,6 +19,7 @@ limitations under the License.
 #pragma once
 
 #include "enums.h"
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <map>


### PR DESCRIPTION
When I have tried to build yarpgen on ArchLinux
the build failed with
"/home/dima/work/yarpgen/src/options.h:122:5: error: ‘uint64_t’ does not name a type
  122 |     uint64_t getSeed() { return seed; }
      |     ^~~~~~~~
/home/dima/work/yarpgen/src/options.h:28:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’;..."