### PR TITLE
GA: set read-all permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,6 +2,8 @@ name: Build YARPGen and generate sample tests
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: read-all
+
 jobs:
   build-and-run-lin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restrict token permissions used by CI pipeline