### PR TITLE
Fix compilation error with gcc-14.

### DIFF
--- a/src/gen_policy.cpp
+++ b/src/gen_policy.cpp
@@ -537,7 +537,7 @@ void GenPolicy::uniformProbFromMax(std::vector<Probability<T>> &distr,
 
 template <class T, class U>
 void GenPolicy::removeProbability(std::vector<Probability<T>> &orig, U id) {
-    std::remove_if(
+    (void)std::remove_if(
         orig.begin(), orig.end(),
         [&id](Probability<T> &elem) -> bool { return elem.getId() == id; });
 }


### PR DESCRIPTION
With `-Werror` gcc-14.1.1 (with libstdc++-14) emits an error: `error: ignoring return value of _FIter std::remove_if(_FIter, _FIter, _Predicate) ... ...
declared with attribute nodiscard [-Werror=unused-result]`. Use cast to `void` to avoid it.