### PR TITLE
Set C++17 when generating SYCL programs

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -72,6 +72,8 @@ class StdID(enum.IntEnum):
 
     ''' Enum doesn't allow to use '++' in names, so we need this function. '''
     def get_full_pretty_std_name (self):
+        if self.value == StdID.SYCL:
+            return "c++17"
         if self.is_cxx():
             return "c++11"
         return "c99"


### PR DESCRIPTION
Intel's SYCL implementation requires C++17 and this is baked by the SYCL 2020 specification, see:
- 3.9.1. Minimum version of C++ [1]
- 3.3. Normative references [2]

[1]: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:progmodel.minimumcppversion
[2]: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:normativerefs

Without this tweak, generated makefiles are not suitable for building SYCL programs with intel/llvm.