### PR TITLE
[SYCL] Drop FPGA support

### DIFF
--- a/src/program.cpp
+++ b/src/program.cpp
@@ -473,9 +473,6 @@ void ProgramGenerator::emitTest(std::shared_ptr<EmitCtx> ctx,
         stream << "#include <algorithm>\n";
     else if (options.isSYCL()) {
         stream << "#include <CL/sycl.hpp>\n";
-        stream << "#if defined(FPGA) || defined(FPGA_EMULATOR)\n";
-        stream << "    #include <CL/sycl/intel/fpga_extensions.hpp>\n";
-        stream << "#endif\n";
     }
 
     if (options.isISPC()) {
@@ -501,10 +498,6 @@ void ProgramGenerator::emitTest(std::shared_ptr<EmitCtx> ctx,
         stream << "        cpu_selector selector;\n";
         stream << "#elif defined(GPU)\n";
         stream << "        gpu_selector selector;\n";
-        stream << "#elif defined(FPGA_EMULATOR)\n";
-        stream << "        intel::fpga_emulator_selector selector;\n";
-        stream << "#elif defined(FPGA)\n";
-        stream << "        intel::fpga_selector selector;\n";
         stream << "#else\n";
         stream << "        default_selector selector;\n";
         stream << "#endif\n";


### PR DESCRIPTION
FPGA support has been dropped from intel/llvm, see intel/llvm#16929 for more info.