### PR TITLE
Enable msvc testing via wsl

### DIFF
--- a/scripts/README-msvc-wsl.md
+++ b/scripts/README-msvc-wsl.md
@@ -1,0 +1,76 @@
+# Testing MSVC from WSL
+
+YARPGen can drive Microsoft's `cl.exe` (installed on the Windows host, outside
+WSL) as just another compiler in the differential-testing pool, alongside the
+Linux gcc/clang. This is done through [`cl-proxy`](cl-proxy), a shim that
+presents a GCC/Clang-style command line and forwards to MSVC — the same idea as
+[`ispc-proxy`](ispc-proxy).
+
+## Requirements
+
+- **Visual Studio (Build Tools) 2019/2022/2026** installed on the Windows host.
+  `cl-proxy` auto-detects `vcvars64.bat` in the common install locations; set
+  `YARPGEN_VCVARS` to its full Windows path if detection fails.
+- **`scripts/` on your `PATH`** so `make` can find `cl-proxy` (same as
+  `ispc-proxy`).
+- **Run everything under `/mnt/<drive>/`** (e.g. `/mnt/c/...`). `cl.exe` cannot
+  see WSL paths like `/home/...`, and the working directory must be a real
+  Windows path. Point `run_gen.py -o` at a `/mnt/c` location.
+- C++ only (`--std c++`). C / ISPC / SYCL are not handled by the proxy.
+
+## Running
+
+For a 1h run:
+```sh
+export PATH="/path/to/yarpgen/scripts:$PATH"
+cd /mnt/c/some/scratch/dir
+run_gen.py --std c++ -o /mnt/c/some/scratch/dir/testing --target "gcc clang msvc" -t 60
+```
+
+`run_gen.py` automatically passes `--max-array-dims=3` to the generator whenever
+an MSVC target is selected (see below). The MSVC compiler spec and the
+`msvc_no_opt` / `msvc_opt` testing sets live in [`test_sets.txt`](test_sets.txt).
+
+## Why the array-dimension cap
+
+The loop generator produces arrays with up to 7 dimensions of size 10–25, i.e.
+multi-gigabyte globals. gcc/clang handle these with `-mcmodel=large`; **MSVC has
+no large-memory model and a hard 2 GB image limit**, so the default programs often
+won't link. The generator therefore gained `--max-array-dims=<n>` (default `0` =
+no explicit cap), and `run_gen.py` sets it to `3` when MSVC is in the pool so the
+shared test fits every compiler. Tune the value if you want larger arrays.
+
+## Why `/permissive-`
+
+`cl.exe` keeps alive some language extensions and known bugs to allow for backwards
+compatibility. yarpgen's intended usage is to find unknown compiler bugs, so we wish 
+to filter those out. To that end, `cl-proxy` hardcodes `/permissive-` on 
+every `cl.exe` invocation ([cl-proxy:102](cl-proxy#L102)). This turns off MSVC's 
+non-conforming language extensions.
+
+MSVC does enable `/permissive-` implicitly under `/std:c++20` and `/std:c++latest`, 
+but *not* under `/std:c++14` / `/std:c++17`, where the default is `/permissive`. 
+Passing `/permissive-` explicitly keeps conformance behavior uniform across the 
+whole `--std` range.
+
+If you're chasing a suspected MSVC-extension issue and *want* the permissive
+front end, drop `/permissive-` from the list in `translate()` — there's no
+environment knob for it.
+
+## How cl-proxy works
+
+1. **Flag translation** — `-c`→`/c`, `-o X`→`/Fo:X` (compile) or `/Fe:X.exe`
+   (link), `-O0`→`/Od`, `-O2/3`→`/O2`, `-std=c++NN`→`/std:...`, and it drops
+   flags MSVC has no use for (`-fPIC`, `-mcmodel=large`, `-march=...`, ...).
+   Every invocation also gets `/nologo /EHsc /w /permissive-` (see below).
+2. **Environment caching** — `vcvars64.bat` takes ~25 s, so running it per
+   compile is unworkable. On first use `cl-proxy` captures the MSVC environment
+   once into `~/.cache/yarpgen_msvc_env.json` (override with
+   `YARPGEN_MSVC_ENV_CACHE`), then invokes `cl.exe` directly (~0.5 s/call),
+   forwarding `INCLUDE`/`LIB`/`LIBPATH` to the Win32 process via `WSLENV`. Delete
+   the cache file to refresh it (e.g. after a VS update). If `cl.exe` can't be
+   located it falls back to a slower `cmd.exe` + `vcvars` path.
+3. **Executable launcher** — MSVC produces a Windows `.exe`; `cl-proxy` writes a
+   small shell launcher (the extension-less name the harness expects) that runs
+   the `.exe` and strips CRLF from its output, so its checksum matches the
+   LF-terminated output of the other compilers.

--- a/scripts/cl-proxy
+++ b/scripts/cl-proxy
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+###############################################################################
+#
+# Copyright (c) 2024, Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+###############################################################################
+# cl-proxy presents a GCC/Clang-style command-line interface backed by MSVC's
+# cl.exe, so YARPGen's testing harness can drive MSVC from WSL without any
+# changes to the (GCC-flag-centric) Makefile generator. It is the MSVC
+# counterpart of ispc-proxy / ispc-disp.
+#
+# It does three things:
+#   1. Translates the GCC-style flags the harness emits into cl.exe syntax.
+#   2. Invokes cl.exe through cmd.exe with the MSVC environment loaded
+#      (vcvars64.bat).
+#   3. Wraps the produced Windows .exe in a tiny shell launcher that also
+#      strips CRLF from its output, so the rest of the harness can treat it as
+#      an ordinary native binary and its checksum matches other compilers'.
+#
+# REQUIREMENTS / GOTCHAS
+#   * Run the whole flow from a Windows-visible directory (under /mnt/<drive>/).
+#     cl.exe cannot see WSL paths such as /home/..., and cmd.exe refuses a UNC
+#     working directory (\\wsl$\...). Point YARPGen's --out-dir / run_gen at a
+#     /mnt/c path.
+#   * Put this scripts/ directory on your PATH (same as ispc-proxy).
+#   * Set YARPGEN_VCVARS to your vcvars64.bat if auto-detection fails.
+#   * C++ only. C / ISPC / SYCL are not handled.
+###############################################################################
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Candidate locations for vcvars64.bat (Build Tools and full VS, 2026/2022/2019,
+# both Program Files roots). YARPGEN_VCVARS overrides all of them.
+# Built from version-dirs x editions x install roots. Newest-first so
+# find_vcvars() defaults to the newest installed toolchain. Note the install
+# directory is a version number, not the marketing year: VS 2026 is "18", VS
+# 2022 is "2022"/"17". We list both the version and the year spelling to be safe.
+_VS_YEARS = ["18", "2026", "17", "2022", "2019"]
+_VS_EDITIONS = ["BuildTools", "Community", "Professional", "Enterprise"]
+_VS_ROOTS = ["C:\\Program Files", "C:\\Program Files (x86)"]
+_VCVARS_CANDIDATES = [
+    "%s\\Microsoft Visual Studio\\%s\\%s\\VC\\Auxiliary\\Build\\vcvars64.bat"
+    % (root, year, edition)
+    for year in _VS_YEARS
+    for edition in _VS_EDITIONS
+    for root in _VS_ROOTS
+]
+
+
+def win_path_to_wsl(win_path):
+    p = win_path.strip().strip('"')
+    m = re.match(r"^([A-Za-z]):\\(.*)$", p)
+    if not m:
+        return None
+    drive, rest = m.group(1).lower(), m.group(2).replace("\\", "/")
+    return "/mnt/%s/%s" % (drive, rest)
+
+
+def find_vcvars():
+    env = os.environ.get("YARPGEN_VCVARS")
+    if env:
+        return env
+    for cand in _VCVARS_CANDIDATES:
+        wsl = win_path_to_wsl(cand)
+        if wsl and os.path.isfile(wsl):
+            return cand
+    # Fall back to the first candidate so we produce a clear error from cmd.exe.
+    return _VCVARS_CANDIDATES[0]
+
+
+VCVARS = find_vcvars()
+
+# Exact flags with no MSVC equivalent that we intentionally drop.
+DROP_EXACT = {
+    "-fPIC", "-fpermissive", "-fno-strict-aliasing", "-w",
+    "-fno-sanitize-recover=undefined", "--pic",
+}
+# Flag prefixes to drop (arch selection, sanitizers, linker libs, warnings...).
+DROP_PREFIX = (
+    "-march=", "-mcmodel", "--mcmodel", "-x", "-W", "-fsanitize", "-mllvm",
+    "--target", "-woff", "-rtlib", "-l",
+)
+
+
+def map_std(std):
+    # MSVC /std: accepts c++14, c++17, c++20, c++latest (min is c++14).
+    table = {
+        "c++98": "c++14", "c++03": "c++14", "c++11": "c++14", "c++0x": "c++14",
+        "c++14": "c++14", "c++1y": "c++14", "c++17": "c++17", "c++1z": "c++17",
+        "c++20": "c++20", "c++2a": "c++20", "c++23": "c++latest",
+        "c++2b": "c++latest",
+    }
+    return table.get(std, "c++17")
+
+
+def translate(argv):
+    """GCC-style argv -> (cl args, is_compile_only, output_target)."""
+    out = ["/nologo", "/EHsc", "/w", "/permissive-"]
+    compiling = "-c" in argv
+    target = None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "-c":
+            out.append("/c")
+        elif a == "-o":
+            i += 1
+            target = argv[i]
+        elif a == "-O0":
+            out.append("/Od")
+        elif re.fullmatch(r"-O[123sg]", a) or a == "-Ofast":
+            out.append("/O2")
+        elif a.startswith("-std="):
+            out.append("/std:" + map_std(a[len("-std="):]))
+        elif a == "-fopenmp-simd" or a == "-fopenmp":
+            out.append("/openmp:experimental")
+        elif a.startswith("-D"):
+            out.append("/D" + a[2:])
+        elif a.startswith("-I"):
+            out.append("/I" + a[2:])
+        elif a in DROP_EXACT or any(a.startswith(p) for p in DROP_PREFIX):
+            pass
+        elif a.startswith("/"):
+            out.append(a)          # already a cl flag -> pass through
+        elif a.startswith("-"):
+            sys.stderr.write("cl-proxy: dropping unknown flag '%s'\n" % a)
+        else:
+            out.append(a)          # source or object file
+        i += 1
+    return out, compiling, target
+
+
+def make_launcher(name, exe):
+    with open(name, "w") as f:
+        f.write("#!/bin/bash\n")
+        f.write("# Auto-generated by cl-proxy: run the MSVC-built binary and\n")
+        f.write("# normalize CRLF so its checksum matches other compilers.\n")
+        f.write("set -o pipefail\n")
+        f.write('"$(dirname "$0")/%s" "$@" | tr -d "\\r"\n' % exe)
+    os.chmod(name, 0o755)
+
+
+# Cache of the MSVC environment so we do not pay the ~25s vcvars cost per call.
+CACHE = os.environ.get("YARPGEN_MSVC_ENV_CACHE",
+                       os.path.expanduser("~/.cache/yarpgen_msvc_env.json"))
+
+
+def capture_msvc_env():
+    """Run vcvars once (via a .bat, to dodge cmd.exe quoting) and record cl.exe's
+    path plus the INCLUDE/LIB/LIBPATH it sets. Returns {} on failure."""
+    bat = "_clproxy_env_%d.bat" % os.getpid()
+    try:
+        with open(bat, "w", newline="\r\n") as f:
+            f.write("@echo off\n")
+            f.write('call "%s" >nul\n' % VCVARS)
+            f.write("set\n")
+        out = subprocess.check_output(["cmd.exe", "/C", bat],
+                                      stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        return {}
+    finally:
+        try:
+            os.remove(bat)
+        except OSError:
+            pass
+
+    env = {}
+    for line in out.decode("utf-8", "replace").splitlines():
+        if "=" in line:
+            k, v = line.rstrip("\r\n").split("=", 1)
+            env[k] = v
+    cl = None
+    for d in env.get("Path", env.get("PATH", "")).split(";"):
+        wd = win_path_to_wsl(d)
+        if wd and os.path.isfile(os.path.join(wd, "cl.exe")):
+            cl = os.path.join(wd, "cl.exe")
+            break
+    if not cl:
+        return {}
+    data = {"cl": cl,
+            "vars": {k: env[k] for k in ("INCLUDE", "LIB", "LIBPATH")
+                     if k in env}}
+    try:
+        os.makedirs(os.path.dirname(CACHE), exist_ok=True)
+        with open(CACHE, "w") as f:
+            json.dump(data, f)
+    except OSError:
+        pass
+    return data
+
+
+def load_msvc_env():
+    try:
+        with open(CACHE) as f:
+            data = json.load(f)
+        if data.get("cl") and os.path.isfile(data["cl"]):
+            return data
+    except (OSError, ValueError):
+        pass
+    return capture_msvc_env()
+
+
+def run_via_bat(cl_args):
+    """Slow fallback: run cl through cmd.exe + vcvars for every invocation."""
+    cl_cmd = "cl " + " ".join(cl_args)
+    bat = "_clproxy_%d.bat" % os.getpid()
+    with open(bat, "w", newline="\r\n") as f:
+        f.write("@echo off\n")
+        f.write('call "%s" >nul\n' % VCVARS)
+        f.write(cl_cmd + "\n")
+        f.write("exit /b %errorlevel%\n")
+    try:
+        return subprocess.call(["cmd.exe", "/C", bat])
+    finally:
+        try:
+            os.remove(bat)
+        except OSError:
+            pass
+
+
+def run_direct(data, cl_args):
+    """Fast path: invoke cl.exe directly, forwarding the cached INCLUDE/LIB/
+    LIBPATH to the Win32 process via WSLENV (verbatim, no path translation)."""
+    env = dict(os.environ)
+    for k, v in data["vars"].items():
+        env[k] = v
+    names = ":".join(data["vars"].keys())
+    if names:
+        prev = os.environ.get("WSLENV", "")
+        env["WSLENV"] = (prev + ":" + names) if prev else names
+    return subprocess.call([data["cl"]] + cl_args, env=env)
+
+
+def main():
+    args, compiling, target = translate(sys.argv[1:])
+    exe_out = None
+    if target is not None:
+        if compiling:
+            args.append("/Fo:" + target)
+        else:
+            exe_out = target + ".exe"
+            args.append("/Fe:" + exe_out)
+
+    data = load_msvc_env()
+    if data.get("cl"):
+        rc = run_direct(data, args)
+    else:
+        # Could not locate cl.exe; fall back to the slow cmd.exe + vcvars path.
+        rc = run_via_bat(args)
+
+    if rc == 0 and exe_out is not None:
+        make_launcher(target, exe_out)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_gen.py
+++ b/scripts/run_gen.py
@@ -63,7 +63,7 @@ script_start_time = datetime.datetime.now()  # We should init variable, so let's
 
 known_build_fails = { \
 # clang
-    "Assertion `NodeToMatch\-\>getOpcode\(\) != ISD::DELETED_NODE && \"NodeToMatch was removed partway through selection\"'": "SelectionDAGISel", \
+    r"Assertion `NodeToMatch\-\>getOpcode\(\) != ISD::DELETED_NODE && \"NodeToMatch was removed partway through selection\"'": "SelectionDAGISel", \
     "replaceAllUses of value with new value of different type": "replaceAllUses", \
     "Concatenation of vectors with inconsistent value types": "FoldCONCAT_VECTORS", \
     "Integer type overpromoted": "PromoteIntRes_SETCC", \
@@ -210,6 +210,14 @@ class Test(object):
                             "--std=" + common.StdID.get_pretty_std_name(common.selected_standard)]
         if seed:
             yarpgen_run_list += ["-s", seed]
+        # MSVC (driven via cl-proxy) has no large-memory model and a 2GB image
+        # limit, so the default multi-GB arrays won't link. When an MSVC target
+        # is selected, cap the array dimensions so the shared test fits.
+        msvc_selected = any(
+            getattr(t.specs, "comp_cxx_name", "") == "cl-proxy"
+            for t in gen_test_makefile.CompilerTarget.all_targets)
+        if msvc_selected:
+            yarpgen_run_list.append("--max-array-dims=3")
         self.yarpgen_cmd = " ".join(str(p) for p in yarpgen_run_list)
         self.ret_code, self.stdout, self.stderr, self.is_time_expired, self.elapsed_time = \
             common.run_cmd(yarpgen_run_list, yarpgen_timeout, proc_num, yarpgen_mem_limit)
@@ -512,10 +520,10 @@ class Test(object):
             init_h.close()
             init_h = open("init.h", "w")
             for l in init_h_content:
-                if not (remove_iostream and re.search("\<iostream\>", l) or \
-                        remove_array and re.search("\<array\>", l) or \
-                        remove_vector and re.search("\<vector\>", l) or \
-                        remove_valarray and re.search("\<valarray\>", l)):
+                if not (remove_iostream and re.search(r"\<iostream\>", l) or \
+                        remove_array and re.search(r"\<array\>", l) or \
+                        remove_vector and re.search(r"\<vector\>", l) or \
+                        remove_valarray and re.search(r"\<valarray\>", l)):
                     init_h.write(l)
             init_h.close()
 
@@ -1451,7 +1459,7 @@ def check_creduce_version():
     try:
         ret_code, stdout, stderr, time_expired, elapsed_time = common.run_cmd([creduce_bin, "--help"], yarpgen_timeout, 0)
         stdout_str = str(stdout, "utf-8")
-        match = re.match("creduce (\d+)\.(\d+)\.(\d+).*", stdout_str)
+        match = re.match(r"creduce (\d+)\.(\d+)\.(\d+).*", stdout_str)
         if not match:
             common.print_and_exit("Can't read creduce version.")
         major = int(match.group(1))

--- a/scripts/test_sets.txt
+++ b/scripts/test_sets.txt
@@ -62,7 +62,7 @@ ubsan_clang_o0   | ubsan_clang | -O0       |                |
 ubsan_gcc_o0     | ubsan_gcc   | -O0       |                |
 #ubsan_gcc_o2     | ubsan_gcc   | -O2       |                |
 
-#gcc_no_opt       | gcc       | -O0       |                |
+gcc_no_opt       | gcc       | -O0       |                |
 gcc_opt          | gcc       | -O3       |                |
 #gcc_wsm_opt      | gcc       | -O3       | westmere       | wsm
 #gcc_ivb_opt      | gcc       | -O3       | ivybridge      | ivb
@@ -71,13 +71,13 @@ gcc_opt          | gcc       | -O3       |                |
 #gcc_knl_no_opt   | gcc       | -O0       | knl            | knl
 #gcc_knl_opt      | gcc       | -O3       | knl            | knl
 #gcc_skx_no_opt   | gcc       | -O0       | skylake-avx512 | skx
-#gcc_skx_opt      | gcc       | -O3       | skylake-avx512 | skx
+gcc_skx_opt      | gcc       | -O3       | skylake-avx512 | skx
 #gcc_icx_no_opt   | gcc       | -O0       | icelake-server | icx
 #gcc_icx_opt      | gcc       | -O3       | icelake-server | icx
 #gcc_tgl_no_opt   | gcc       | -O0       | tigerlake      | tgl
 #gcc_tgl_opt      | gcc       | -O3       | tigerlake      | tgl
 #gcc_spr_no_opt   | gcc       | -O0       | sapphirerapids | spr
-#gcc_spr_opt      | gcc       | -O3       | sapphirerapids | spr
+gcc_spr_opt      | gcc       | -O3       | sapphirerapids | spr
 
 clang_no_opt     | clang     | -O0       |                |
 clang_opt        | clang     | -O3       |                |

--- a/scripts/test_sets.txt
+++ b/scripts/test_sets.txt
@@ -45,6 +45,9 @@ icc         | icpc                | icc               | -fPIC -mcmodel=large -w 
 icx         | icpx                | icx               | -fPIC -mcmodel=large -w -fopenmp-simd -mllvm -vec-threshold=0                    | -march=
 dpcpp       | clang++             | clang             | -fsycl -w                                                   | -march=
 ispc        | ispc-proxy          | ispc-proxy        | -woff --pic --mcmodel=large                                 | --target=
+# MSVC via cl-proxy (WSL). C++ only. Put scripts/ on PATH and run from /mnt/c.
+# See cl-proxy header for setup (YARPGEN_VCVARS, working directory).
+msvc        | cl-proxy            | cl-proxy          |                                                             |
 
 Testing sets:
 # Set name - codename for testing set
@@ -59,7 +62,7 @@ ubsan_clang_o0   | ubsan_clang | -O0       |                |
 ubsan_gcc_o0     | ubsan_gcc   | -O0       |                |
 #ubsan_gcc_o2     | ubsan_gcc   | -O2       |                |
 
-gcc_no_opt       | gcc       | -O0       |                |
+#gcc_no_opt       | gcc       | -O0       |                |
 gcc_opt          | gcc       | -O3       |                |
 #gcc_wsm_opt      | gcc       | -O3       | westmere       | wsm
 #gcc_ivb_opt      | gcc       | -O3       | ivybridge      | ivb
@@ -68,13 +71,13 @@ gcc_opt          | gcc       | -O3       |                |
 #gcc_knl_no_opt   | gcc       | -O0       | knl            | knl
 #gcc_knl_opt      | gcc       | -O3       | knl            | knl
 #gcc_skx_no_opt   | gcc       | -O0       | skylake-avx512 | skx
-gcc_skx_opt      | gcc       | -O3       | skylake-avx512 | skx
+#gcc_skx_opt      | gcc       | -O3       | skylake-avx512 | skx
 #gcc_icx_no_opt   | gcc       | -O0       | icelake-server | icx
 #gcc_icx_opt      | gcc       | -O3       | icelake-server | icx
 #gcc_tgl_no_opt   | gcc       | -O0       | tigerlake      | tgl
 #gcc_tgl_opt      | gcc       | -O3       | tigerlake      | tgl
 #gcc_spr_no_opt   | gcc       | -O0       | sapphirerapids | spr
-gcc_spr_opt      | gcc       | -O3       | sapphirerapids | spr
+#gcc_spr_opt      | gcc       | -O3       | sapphirerapids | spr
 
 clang_no_opt     | clang     | -O0       |                |
 clang_opt        | clang     | -O3       |                |
@@ -88,6 +91,11 @@ clang_skx_opt    | clang     | -O3       | skx            | skx
 #clang_tgl_opt    | clang     | -O3       | tigerlake      | tgl
 #clang_spr_no_opt | clang     | -O0       | sapphirerapids | spr
 clang_spr_opt    | clang     | -O3       | sapphirerapids | spr
+
+msvc_no_opt      | msvc      | -O0             |                |
+msvc_opt         | msvc      | -O2             |                |
+# /arch:AVX2 exercises MSVC's auto-vectorizer far more than the SSE2 default.
+msvc_avx2_opt    | msvc      | -O2 /arch:AVX2  |                |
 
 #polly_no_opt     | polly     | -O0       |                |
 polly_opt        | polly     | -O3       |                |

--- a/src/enums.h
+++ b/src/enums.h
@@ -163,6 +163,7 @@ enum class OptionKind {
     MUTATE,
     MUTATION_SEED,
     UB_IN_DC,
+    MAX_ARRAY_DIMS,
     MAX_OPTION_ID
 };
 

--- a/src/gen_policy.cpp
+++ b/src/gen_policy.cpp
@@ -359,6 +359,11 @@ GenPolicy::GenPolicy() {
     if (options.isISPC())
         array_dims_num_limit = 4;
 
+    // An explicit cap (e.g. for MSVC, which lacks a large-memory model) wins.
+    if (options.getMaxArrayDims() != 0)
+        array_dims_num_limit =
+            std::min(array_dims_num_limit, options.getMaxArrayDims());
+
     // Arrays with single dimension require a separate treatment. Otherwise, we
     // do not get the desired distribution.
     stencil_in_dim_prob.emplace(

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -204,6 +204,16 @@ std::vector<OptionDescr> yarpgen::OptionParser::options_set{
      OptionParser::parseAllowUBInDC,
      "none",
      {"none", "some", "all"}},
+    {OptionKind::MAX_ARRAY_DIMS,
+     "",
+     "--max-array-dims",
+     true,
+     "Upper bound on array dimensions (0 = generator default). Lower it to fit "
+     "compilers without a large-memory model, e.g. MSVC",
+     "Can't parse max array dims",
+     OptionParser::parseMaxArrayDims,
+     "0",
+     {}},
 };
 
 static void dumpVersion(std::ostream &stream) {
@@ -511,6 +521,15 @@ void OptionParser::parseAllowUBInDC(std::string allow_ub_in_dc_str) {
         options.setAllowUBInDC(OptionLevel::ALL);
     else
         printHelpAndExit("Can't recognize input as arguments use level");
+}
+
+void OptionParser::parseMaxArrayDims(std::string max_array_dims_str) {
+    Options &options = Options::getInstance();
+    try {
+        options.setMaxArrayDims(std::stoul(max_array_dims_str));
+    } catch (std::exception &) {
+        printHelpAndExit("Can't parse max array dims");
+    }
 }
 
 void Options::dump(std::ostream &stream) {

--- a/src/options.h
+++ b/src/options.h
@@ -99,6 +99,7 @@ class OptionParser {
     static void parseMutationKind(std::string mutate_str);
     static void parseMutationSeed(std::string mutation_seed_str);
     static void parseAllowUBInDC(std::string allow_ub_in_dc_str);
+    static void parseMaxArrayDims(std::string max_array_dims_str);
 };
 
 class Options {
@@ -168,6 +169,14 @@ class Options {
     void setAllowUBInDC(OptionLevel _val) { allow_ub_in_dc = _val; }
     OptionLevel getAllowUBInDC() { return allow_ub_in_dc; }
 
+    // Upper bound on the number of array dimensions. Zero means "no explicit
+    // limit" (the generator's own default applies). Lowering this shrinks the
+    // generated arrays, which is required to fit compilers without a
+    // large-memory model (e.g. MSVC, which has no -mcmodel=large and a 2GB
+    // image limit).
+    void setMaxArrayDims(size_t _val) { max_array_dims = _val; }
+    size_t getMaxArrayDims() { return max_array_dims; }
+
     void dump(std::ostream &stream);
 
   private:
@@ -179,7 +188,7 @@ class Options {
           emit_pragmas(OptionLevel::SOME), out_dir("."),
           use_param_shuffle(false), expl_loop_params(false),
           mutation_kind(MutationKind::NONE), mutation_seed(0),
-          allow_ub_in_dc(OptionLevel::NONE) {}
+          allow_ub_in_dc(OptionLevel::NONE), max_array_dims(0) {}
 
     std::vector<std::string> raw_options;
 
@@ -210,5 +219,8 @@ class Options {
 
     // If we want to allow Undefined Behavior in Dead Code
     OptionLevel allow_ub_in_dc;
+
+    // Upper bound on array dimensions (0 = no explicit limit).
+    size_t max_array_dims;
 };
 } // namespace yarpgen

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -97,6 +97,17 @@ static void emitVarsDecl(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
     ctx->setSYCLPrefix("");
 }
 
+// Emit an alignment specifier as a declaration *prefix*. We use the standard
+// C++11 `alignas`, which GCC, Clang and MSVC all accept. MSVC does not accept
+// the trailing GNU `__attribute__((aligned(...)))`, and its `__declspec` is a
+// prefix specifier, so a prefix `alignas` is the portable choice. For C we keep
+// the GNU attribute (MSVC support is C++ only).
+static std::string alignAttr(size_t alignment) {
+    if (Options::getInstance().isC())
+        return "__attribute__((aligned(" + std::to_string(alignment) + ")))";
+    return "alignas(" + std::to_string(alignment) + ")";
+}
+
 static void emitArrayDecl(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
                           std::vector<std::shared_ptr<Array>> arrays) {
     Options &options = Options::getInstance();
@@ -106,14 +117,13 @@ static void emitArrayDecl(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
         auto type = array->getType();
         assert(type->isArrayType() && "Array should have an Array type");
         auto array_type = std::static_pointer_cast<ArrayType>(type);
+        if (array->getAlignment() != 0)
+            stream << alignAttr(array->getAlignment()) << " ";
         stream << array_type->getBaseType()->getName(ctx) << " ";
         stream << array->getName(ctx) << " ";
         for (const auto &dimension : array_type->getDimensions()) {
             stream << "[" << dimension << "] ";
         }
-        if (array->getAlignment() != 0)
-            stream << "__attribute__((aligned(" << array->getAlignment()
-                   << ")))";
         stream << ";\n";
     }
 }
@@ -325,14 +335,10 @@ static void emitArrayExtDecl(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
         auto type = array->getType();
         assert(type->isArrayType() && "Array should have an Array type");
         auto array_type = std::static_pointer_cast<ArrayType>(type);
-        stream << "extern ";
-        stream << array_type->getBaseType()->getName(ctx);
-        stream << " ";
-        stream << array->getName(ctx) << " ";
-        for (const auto &dimension : array_type->getDimensions()) {
-            stream << "[" << dimension << "] ";
-        }
 
+        // Decide on the alignment before emitting the declaration: the
+        // alignment specifier has to be emitted as a prefix (see alignAttr).
+        size_t alignment = 0;
         if (options.isCXX() &&
             options.getEmitAlignAttr() != OptionLevel::NONE) {
             bool emit_align_attr = true;
@@ -344,7 +350,6 @@ static void emitArrayExtDecl(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
                 if (!options.getUniqueAlignSize())
                     align_size =
                         rand_val_gen->getRandId(emit_pol->align_size_distr);
-                size_t alignment = 0;
                 switch (align_size) {
                     case AlignmentSize::A16:
                         alignment = 16;
@@ -359,10 +364,21 @@ static void emitArrayExtDecl(std::shared_ptr<EmitCtx> ctx, std::ostream &stream,
                         ERROR("Bad alignment size");
                 }
                 array->setAlignment(alignment);
-                stream << "__attribute__((aligned(" << alignment << ")))";
             }
         }
 
+        // The alignment specifier must precede all decl-specifiers (i.e. come
+        // before `extern`); placing it between `extern` and the type is
+        // ill-formed for a standard attribute.
+        if (alignment != 0)
+            stream << alignAttr(alignment) << " ";
+        stream << "extern ";
+        stream << array_type->getBaseType()->getName(ctx);
+        stream << " ";
+        stream << array->getName(ctx) << " ";
+        for (const auto &dimension : array_type->getDimensions()) {
+            stream << "[" << dimension << "] ";
+        }
         stream << ";\n";
     }
 }


### PR DESCRIPTION
The yarpgen code was made to run on linux/mac. While it may be possible to make it runnable on windows, turns out it wasn't necessary for testing msvc. Instead, I added the `cl-proxy` bash script (modeled after `ispc-proxy`), and ran yarpgen on WSL. It quickly gave a few new msvc miscompilation bug reports:

* https://developercommunity.visualstudio.com/t/MSVC-O2-miscompiles-short-to-unsigned-w/11127140
* https://developercommunity.visualstudio.com/t/MSVC-O1-and-O2-miscompiles-signed-modu/11125055
* https://developercommunity.visualstudio.com/t/MSVC-miscompiles-unsigned-long-long-expr/11126097
* https://developercommunity.visualstudio.com/t/MSVC-O1-miscompiles-nested-array-loop/11126250

Only a few adjustments were made to the common code: addition of a `max-array-dims` switch, and abstraction of `alignAttr`. The mechanism is described in some detail `README-msvc-wsl.md`.

Thanks for this very nice project, and hope you'll agree to merge this upstream.